### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/_test/main.tf
+++ b/_test/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     github = {
-      source  = "integrations/github"
+      source = "integrations/github"
     }
   }
   required_version = ">= 0.13"
@@ -12,7 +12,7 @@ provider "aws" {
 }
 
 module "iam_role" {
-  source  = "./.."
+  source = "./.."
 
   github_repository           = github_repository.example
   iam_openid_connect_provider = aws_iam_openid_connect_provider.github

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "this" {
   assume_role_policy   = data.aws_iam_policy_document.this.json
   max_session_duration = var.max_session_duration
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.iam_role_tags)
 }
 
 data "aws_iam_policy_document" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,15 @@ https://docs.github.com/en/actions/deployment/security-hardening-your-deployment
 EOS
 }
 
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "github_repository" {
   type = object({
     full_name = string
@@ -55,6 +64,15 @@ https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/i
 EOS
 }
 
+variable "iam_role_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the IAM role.
+EOS
+}
+
 variable "max_session_duration" {
   type    = number
   default = null
@@ -78,14 +96,5 @@ The default value in this module corresponds with the default value passed by
 the `aws-actions/configure-aws-credentials` GitHub Action.
 
 https://github.com/aws-actions/configure-aws-credentials
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags used on all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.