### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role" "this" {
   assume_role_policy   = data.aws_iam_policy_document.this.json
   max_session_duration = var.max_session_duration
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 data "aws_iam_policy_document" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,15 @@ https://docs.github.com/en/actions/deployment/security-hardening-your-deployment
 EOS
 }
 
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "github_repository" {
   type = object({
     full_name = string
@@ -78,14 +87,5 @@ The default value in this module corresponds with the default value passed by
 the `aws-actions/configure-aws-credentials` GitHub Action.
 
 https://github.com/aws-actions/configure-aws-credentials
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.